### PR TITLE
Support single curly braces in template parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
+-
+
+## [0.2.0]
+
+- Support single curly braces `{name}` for required fields to simplify templating
+
+## [0.0.2] - 2025-06-28
+
+- Support for `--help` and `--debug` flags to studio-mcp itself.
+- Improved handling of templated command arguments.
+
+## [0.0.1] - 2025-06-28
+
+### Added
+- Initial TypeScript port of `studio` from Ruby
 - MCP server implementation using @modelcontextprotocol/sdk
 - Blueprint templating
-- Support for required `{name}` (preferred) and optional `[name]` string arguments
-- Support for array arguments `[name...]` and required arrays `{name...}`
-- Double curly braces `{{name}}` remain supported for backward compatibility
+- Support for required `{{name}}` and optional `[name]` string arguments
+- Support for array arguments `[name...]`
 - CLI interface compatible with Claude Desktop, Cursor, and other MCP clients

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
 
-## [0.0.2] - 2025-06-28
-
-- Support for `--help` and `--debug` flags to studio itself.
-- Improved handling of templated command arguments.
-
-## [0.0.1] - 2025-06-28
-
-### Added
-- Initial TypeScript port of `studio` from Ruby
 - MCP server implementation using @modelcontextprotocol/sdk
 - Blueprint templating
-- Support for required `{{name}}` and optional `[name]` string arguments
-- Support for array arguments `[name...]`
+- Support for required `{name}` (preferred) and optional `[name]` string arguments
+- Support for array arguments `[name...]` and required arrays `{name...}`
+- Double curly braces `{{name}}` remain supported for backward compatibility
 - CLI interface compatible with Claude Desktop, Cursor, and other MCP clients

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The tool turns everything after `studio` command into an MCP tool that can be ca
 It uses a very simple Mustache-like template syntax to provide inputs and descriptions telling the LLM how to use your command.
 
 ```sh
-$ npx -y @studio-mcp/studio command "{{ required_argument # Description of argument }}" "[optional_args... # any array of arguments]"
+$ npx -y @studio-mcp/studio command "{ required_argument # Description of argument }" "[optional_args... # any array of arguments]"
 ```
 
 `studio` turns this into an input schema for the MCP tool so that tool calls know what to send:
@@ -66,7 +66,7 @@ It should open your Claude Desktop MCP configuration. (e.g. `~/Library/Applicati
   "mcpServers": {
     "say": {
       "command": "npx",
-      "args": ["-y", "@studio-mcp/studio", "say", "-v", "siri", "{{speech # A concise message to say outloud}}"]
+      "args": ["-y", "@studio-mcp/studio", "say", "-v", "siri", "{speech # A concise message to say outloud}"]
     },
   }
 }
@@ -83,7 +83,7 @@ Add to your `~/.cursor/mcp.json` (in your home or project directory) or go to To
   "mcpServers": {
     "say": {
       "command": "npx",
-      "args": ["-y", "@studio-mcp/studio", "say", "-v", "siri", "{{speech#say_outloud}}"]
+      "args": ["-y", "@studio-mcp/studio", "say", "-v", "siri", "{speech#say_outloud}"]
     },
   }
 }
@@ -101,7 +101,7 @@ It's a lot of the same here. Don't get confused betwee studio and stdio (that's 
         "type": "stdio",
         "command": "npx",
 
-        "args": ["-y", "@studio-mcp/studio", "echo", "{{text#What do you want to say?}}"]
+        "args": ["-y", "@studio-mcp/studio", "echo", "{text#What do you want to say?}"]
       }
     }
   }
@@ -113,26 +113,28 @@ It's a lot of the same here. Don't get confused betwee studio and stdio (that's 
 Studio uses blueprints (templates) to keep your studio tidy.
 
 ```bash
-studio say -v "{{voice# Choose your Mac say voice}}" "[args...#Any additional args]"
+studio say -v "{voice# Choose your Mac say voice}" "[args...#Any additional args]"
 ```
 
 This creates a Studio server with two arguments: `voice` and `args`.
 Everything after the `#` will be used as the description for the LLM to understand.
 
-Blueprint templates are a modified mustache format with descriptions: `{{name # description}}` but they also add shell like optional `[--flag]` booleans, `[optional # an optional string]` and `[args... # array with 0 or more strings]` for additional args:
+Blueprint templates are a modified mustache format with descriptions: `{name # description}` but they also add shell like optional `[--flag]` booleans, `[optional # an optional string]` and `[args... # array with 0 or more strings]` for additional args:
 
-- `{{name}}`: Required string argument
+- `{name}`: Required string argument
 - `[name]`: Optional string argument
 - `[name...]`: Optional array argument (spreads as multiple command line args)
 - `[--flag]`: Optional boolean named `flag` that prints `--flag` only when true.
-- `{{name...}}`: Required array (1 or more arguments required).
+- `{name...}`: Required array (1 or more arguments required).
 
 Inside a tag, there is a name and description:
 
 - `name`: The argument name that will be shown in the MCP tool schema. Only letter numbers and underscores (dashes and underscores are interchangeable, case-insensitive).
 - `description`: A description of what the argument should contain. Reads everything after the `#` to the end of the template tag.
 
-#### What about {{cool_template_feature: string /[A-Z]+/ # Fancy tags}}?
+Note: Double curly braces `{{name}}` are still supported for backward compatibility, but single braces `{name}` are preferred and used throughout the docs.
+
+#### What about {cool_template_feature: string /[A-Z]+/ # Fancy tags}?
 
 This is a simple studio, not one of those fancy 1 bedroom flats.
 
@@ -145,7 +147,7 @@ To build and test locally:
 ```bash
 make
 make test
-studio echo "{{text # what you want said to you}}"
+studio echo "{text # what you want said to you}"
 ```
 
 ### Did something break?

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ func parseArgs(args []string) (debugFlag bool, versionFlag bool, logFile string,
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "studio [--debug] [--log filename] [--] <command> --example \"{{req # required arg}}\" \"[args... # array of args]\"",
+	Use:   "studio [--debug] [--log filename] [--] <command> --example \"{req # required arg}\" \"[args... # array of args]\"",
 	Short: "A tool for running a single command MCP server",
 	Long: `studio is a tool for running a single command MCP server.
 
@@ -109,13 +109,13 @@ the command starts at the first non-flag argument:
 
 arguments can be templated as their own shellword or as part of a shellword:
 
-  "{{req # required arg}}" - tell the LLM about a required arg named 'req'.
+  "{req # required arg}" - tell the LLM about a required arg named 'req'.
   "[args... # array of args]" - tell the LLM about an optional array of args named 'args'.
   "[opt # optional string]" - a optional string arg named 'opt' (not in example).
-  "https://en.wikipedia.org/wiki/{{wiki_page_name}}" - an example partially templated words.
+  "https://en.wikipedia.org/wiki/{wiki_page_name}" - an example partially templated words.
 
 Example:
-  studio say -v siri "{{speech # a concise phrase to say outloud to the user}}"`,
+  studio say -v siri "{speech # a concise phrase to say outloud to the user}"`,
 	DisableFlagParsing: true, // Disable cobra's flag parsing so we can do custom parsing
 	Args: func(cmd *cobra.Command, args []string) error {
 		// Custom argument parsing
@@ -133,7 +133,7 @@ Example:
 		}
 
 		if len(commandArgs) == 0 {
-			return fmt.Errorf("usage: studio <command> --example \"{{req # required arg}}\" \"[args... # array of args]\"")
+			return fmt.Errorf("usage: studio <command> --example \"{req # required arg}\" \"[args... # array of args]\"")
 		}
 		return nil
 	},


### PR DESCRIPTION
Add support for single curly braces `{}` for required template arguments, preferring them in documentation while maintaining `{{}}` backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a840414f-45fd-4b2e-bf45-f5f7ec88cc62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a840414f-45fd-4b2e-bf45-f5f7ec88cc62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

