### PR TITLE
Add command configuration file support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,18 +1,19 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@studio-mcp/studio",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.4",
-        "zod": "^3.23.8",
+        "@modelcontextprotocol/sdk": "^1.22.0",
+        "zod": "^3.25.76",
       },
       "devDependencies": {
         "@modelcontextprotocol/inspector": "^0.17.2",
-        "@types/node": "^22.10.1",
-        "tsx": "^4.19.2",
-        "typescript": "^5.7.2",
-        "vitest": "^2.1.8",
+        "@types/node": "^22.19.1",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3",
+        "vitest": "^2.1.9",
       },
     },
   },

--- a/src/studio/config.test.ts
+++ b/src/studio/config.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from "vitest";
+import { loadConfig, filterCommands, getDefaultConfigPath } from "./config.js";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+describe("config", () => {
+  describe("getDefaultConfigPath", () => {
+    test("returns XDG_CONFIG_HOME path when set", () => {
+      const originalXdg = process.env.XDG_CONFIG_HOME;
+      process.env.XDG_CONFIG_HOME = "/custom/config";
+      expect(getDefaultConfigPath()).toBe("/custom/config/studio/config.jsonc");
+      if (originalXdg) {
+        process.env.XDG_CONFIG_HOME = originalXdg;
+      } else {
+        delete process.env.XDG_CONFIG_HOME;
+      }
+    });
+
+    test("returns default path when XDG_CONFIG_HOME not set", () => {
+      const originalXdg = process.env.XDG_CONFIG_HOME;
+      delete process.env.XDG_CONFIG_HOME;
+      expect(getDefaultConfigPath()).toBe(
+        path.join(os.homedir(), ".config", "studio", "config.jsonc"),
+      );
+      if (originalXdg) {
+        process.env.XDG_CONFIG_HOME = originalXdg;
+      }
+    });
+  });
+
+  describe("loadConfig", () => {
+    test("loads valid JSON config", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.json`;
+      fs.writeFileSync(
+        tempFile,
+        JSON.stringify({
+          echo: {
+            description: "Echo command",
+            command: ["echo", "hello"],
+          },
+        }),
+      );
+
+      const config = loadConfig(tempFile);
+      expect(config).toEqual({
+        echo: {
+          description: "Echo command",
+          command: ["echo", "hello"],
+        },
+      });
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("loads valid JSONC with comments", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(
+        tempFile,
+        `{
+          // This is a comment
+          "echo": {
+            "description": "Echo command", // inline comment
+            "command": ["echo", "hello"]
+          }
+          /* Multi-line
+             comment */
+        }`,
+      );
+
+      const config = loadConfig(tempFile);
+      expect(config).toEqual({
+        echo: {
+          description: "Echo command",
+          command: ["echo", "hello"],
+        },
+      });
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("throws error for non-existent file", () => {
+      expect(() => loadConfig("/nonexistent/file.jsonc")).toThrow(
+        "Config file not found",
+      );
+    });
+
+    test("throws error for invalid JSON", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(tempFile, "{ invalid json }");
+
+      expect(() => loadConfig(tempFile)).toThrow("Failed to parse config file");
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("throws error when config is not an object", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(tempFile, "[]");
+
+      expect(() => loadConfig(tempFile)).toThrow("Config must be an object");
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("throws error when command missing command field", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(
+        tempFile,
+        JSON.stringify({
+          echo: {
+            description: "Echo command",
+          },
+        }),
+      );
+
+      expect(() => loadConfig(tempFile)).toThrow(
+        'Command "echo" is missing required "command" field',
+      );
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("throws error when command field is not an array", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(
+        tempFile,
+        JSON.stringify({
+          echo: {
+            command: "echo hello",
+          },
+        }),
+      );
+
+      expect(() => loadConfig(tempFile)).toThrow(
+        'Command "echo": "command" field must be an array',
+      );
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("throws error when command array is empty", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(
+        tempFile,
+        JSON.stringify({
+          echo: {
+            command: [],
+          },
+        }),
+      );
+
+      expect(() => loadConfig(tempFile)).toThrow(
+        'Command "echo": "command" array cannot be empty',
+      );
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("throws error when command array contains non-strings", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(
+        tempFile,
+        JSON.stringify({
+          echo: {
+            command: ["echo", 123],
+          },
+        }),
+      );
+
+      expect(() => loadConfig(tempFile)).toThrow(
+        'Command "echo": all command elements must be strings',
+      );
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("allows optional description", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(
+        tempFile,
+        JSON.stringify({
+          echo: {
+            command: ["echo", "hello"],
+          },
+        }),
+      );
+
+      const config = loadConfig(tempFile);
+      expect(config).toEqual({
+        echo: {
+          command: ["echo", "hello"],
+        },
+      });
+
+      fs.unlinkSync(tempFile);
+    });
+
+    test("throws error when description is not a string", () => {
+      const tempFile = `/tmp/test-config-${Date.now()}.jsonc`;
+      fs.writeFileSync(
+        tempFile,
+        JSON.stringify({
+          echo: {
+            description: 123,
+            command: ["echo", "hello"],
+          },
+        }),
+      );
+
+      expect(() => loadConfig(tempFile)).toThrow(
+        'Command "echo": "description" must be a string',
+      );
+
+      fs.unlinkSync(tempFile);
+    });
+  });
+
+  describe("filterCommands", () => {
+    test("filters to specified commands", () => {
+      const config = {
+        echo: { command: ["echo"] },
+        date: { command: ["date"] },
+        pwd: { command: ["pwd"] },
+      };
+
+      const filtered = filterCommands(config, ["echo", "pwd"]);
+      expect(filtered).toEqual({
+        echo: { command: ["echo"] },
+        pwd: { command: ["pwd"] },
+      });
+    });
+
+    test("throws error when command not found", () => {
+      const config = {
+        echo: { command: ["echo"] },
+      };
+
+      expect(() => filterCommands(config, ["nonexistent"])).toThrow(
+        'Command "nonexistent" not found in config',
+      );
+    });
+
+    test("returns empty object when filtering to empty list", () => {
+      const config = {
+        echo: { command: ["echo"] },
+      };
+
+      const filtered = filterCommands(config, []);
+      expect(filtered).toEqual({});
+    });
+  });
+});

--- a/src/studio/config.ts
+++ b/src/studio/config.ts
@@ -1,0 +1,114 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+/**
+ * Config file schema
+ */
+export interface CommandConfig {
+  description?: string;
+  command: string[];
+}
+
+export interface StudioConfig {
+  [commandName: string]: CommandConfig;
+}
+
+/**
+ * Get XDG config directory
+ */
+function getXdgConfigHome(): string {
+  return process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+}
+
+/**
+ * Get default config file path
+ */
+export function getDefaultConfigPath(): string {
+  return path.join(getXdgConfigHome(), "studio", "config.jsonc");
+}
+
+/**
+ * Strip comments from JSONC content
+ */
+function stripJsonComments(content: string): string {
+  // Remove single-line comments
+  content = content.replace(/\/\/.*$/gm, "");
+
+  // Remove multi-line comments
+  content = content.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  return content;
+}
+
+/**
+ * Load and parse a config file
+ */
+export function loadConfig(configPath: string): StudioConfig {
+  if (!fs.existsSync(configPath)) {
+    throw new Error(`Config file not found: ${configPath}`);
+  }
+
+  const content = fs.readFileSync(configPath, "utf-8");
+  const jsonContent = stripJsonComments(content);
+
+  let config: any;
+  try {
+    config = JSON.parse(jsonContent);
+  } catch (err: any) {
+    throw new Error(`Failed to parse config file: ${err.message}`);
+  }
+
+  // Validate config structure
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    throw new Error("Config must be an object");
+  }
+
+  for (const [name, cmd] of Object.entries(config)) {
+    if (typeof cmd !== "object" || cmd === null) {
+      throw new Error(`Command "${name}" must be an object`);
+    }
+
+    const cmdConfig = cmd as any;
+
+    if (!cmdConfig.command) {
+      throw new Error(`Command "${name}" is missing required "command" field`);
+    }
+
+    if (!Array.isArray(cmdConfig.command)) {
+      throw new Error(`Command "${name}": "command" field must be an array`);
+    }
+
+    if (cmdConfig.command.length === 0) {
+      throw new Error(`Command "${name}": "command" array cannot be empty`);
+    }
+
+    for (const arg of cmdConfig.command) {
+      if (typeof arg !== "string") {
+        throw new Error(`Command "${name}": all command elements must be strings`);
+      }
+    }
+
+    if (cmdConfig.description !== undefined && typeof cmdConfig.description !== "string") {
+      throw new Error(`Command "${name}": "description" must be a string`);
+    }
+  }
+
+  return config as StudioConfig;
+}
+
+/**
+ * Filter config to only include specified commands
+ */
+export function filterCommands(config: StudioConfig, commandNames: string[]): StudioConfig {
+  const filtered: StudioConfig = {};
+
+  for (const name of commandNames) {
+    if (!(name in config)) {
+      throw new Error(`Command "${name}" not found in config`);
+    }
+    filtered[name] = config[name];
+  }
+
+  return filtered;
+}


### PR DESCRIPTION
- Added config file loading from XDG config location (~/.config/studio/config.jsonc)
- Config format supports JSONC with command definitions
- Added --config flag to specify custom config file path
- Added --commands flag to filter which commands to load from config
- Config mode registers multiple MCP tools (one per command)
- Maintains backwards compatibility with template mode
- Added comprehensive test coverage for config module

Config file format:
{
  "command-name": { "description": "Optional description", "command": ["executable", "arg1", "arg2"] } }

Usage:
  studio --config myconfig.jsonc studio --commands "cmd1,cmd2" studio (loads default config if exists)